### PR TITLE
Cancel navigation on invalid required CSP attribute

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -219,11 +219,9 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
   <a>element</a> (|element|)'s <{iframe/csp}> <a>content attribute</a> if all of the
   following statements are true:
 
-  1.  |value| is not the empty string.
+  1.  |value| matches the <a grammar>serialized-policy</a> ABNF grammar defined in [[!CSP]].
 
-  2.  |value| matches the <a grammar>serialized-policy</a> ABNF grammar defined in [[!CSP]].
-
-  3.  One of the following statements is true:
+  2.  One of the following statements is true:
 
       1.  |element|'s [=node document=]'s [=Document/browsing context=]'s
           [=browsing context/required CSP=] is `null`.
@@ -232,7 +230,7 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
           [=policy/subsumed by=] |element|'s [=node document=]'s [=Document/browsing context=]'s
           [=browsing context/required CSP=].
 
-  4.  The result of [=parse a serialized csp as disposition|parsing=] |value| as "`enforce`" has a
+  3.  The result of [=parse a serialized csp as disposition|parsing=] |value| as "`enforce`" has a
       [=policy/directive set=] that does not [=list/contain=] any of the following directives:
 
       *   [=report-uri=]
@@ -341,6 +339,9 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
       11. <a lt="set the required CSP" abstract-op>Set</a> `browsingContext`'s
           <a for="browsing context">required CSP</a>.
 
+      12. If `browsingContext`'s <a for="browsing context">required CSP</a> is `invalid`, cancel the
+          navigation.
+
       ISSUE: Upstream this to WHATWG's HTML.
 
       ISSUE(w3c/html#584): W3C's HTML's navigation algorithm is wildly divergent from WHATWG's at
@@ -382,14 +383,17 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
 
     1.  If |context| is a <a>nested browsing context</a>:
 
-        1.  If |context|'s <a>browsing context container</a> has an <{iframe/csp}> <a>content
+        1.  If |context|'s <a>browsing context container</a> has no <{iframe/csp}> <a>content
+            attribute</a>, or if it has an <{iframe/csp}> <a>content attribute</a> with an emtpy
+            value, set |context|'s <a for="browsing context">required CSP</a> to the value of
+            |context|'s
+            <a>parent browsing context</a>'s <a for="browsing context">required CSP</a> and return.
+
+        2.  If |context|'s <a>browsing context container</a> has an <{iframe/csp}> <a>content
             attribute</a> with a <a for="iframe/csp">valid attribute value</a> (|value|), set
             |context|'s <a for="browsing context">required CSP</a> to |value| and return.
 
-        2.  Set |context|'s <a for="browsing context">required CSP</a> to the value of |context|'s
-            <a>parent browsing context</a>'s <a for="browsing context">required CSP</a>.
-
-        3.  Return.
+        3.  Set |context|'s <a for="browsing context">required CSP</a> to `invalid` and return.
 
     2.  Set |context|'s <a for="browsing context">required CSP</a> to `null`.
   </div>


### PR DESCRIPTION
If the document `A` includes `<iframe src="B" csp="some-policy">`, and `B` includes `<iframe src="C" csp="some-other-policy">` and `some-policy` does not subsume `some-other-policy`, right now CSPEE ignores `some-other-policy` and required from `C` to comply with `some-policy`. This seems dangerous since CSPEE ignores then the requirements from `B`. This changes tries to fix that by canceling the navigation in such a case.