### PR TITLE
Fix examples involving wildcard host matching.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -724,13 +724,13 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
 
     <pre>
       A = http://*.a.com http://*.b.com
-      B = https://a.com:* http://*.c.com
-      intersection = https://a.com
+      B = https://sub.a.com:* http://*.c.com
+      intersection = https://sub.a.com
     </pre>
 
     Only two sources are similar: "http://*.a.com" in |A| is similar to
-    "https://a.com:*" in |B| so the intersection of the two source lists is
-    "https://a.com".
+    "https://sub.a.com:*" in |B| so the intersection of the two source lists is
+    "https://sub.a.com".
 
     <pre>
       A = 'unsafe-inline' http://example.com:443/page1/html 'nonce-abc'
@@ -1014,7 +1014,7 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
 
     <pre>
       A = http://*.example.com
-      B = https://example.com:*
+      B = https://inner.example.com:*
     </pre>
 
     Even though |A| and |B|'s ports are different, |A| and |B| are similar


### PR DESCRIPTION
According to the CSP spec, "*.example.com" should not match
"example.com". Since for the subsumption algorithm the CSPEE spec
refers to the CSP spec for host matching, the same holds for CSPEE.

This change fixes a few examples in the CSPEE spec that are not
consistent with that.