### PR TITLE
Fix example of non-similar CSP sources with different ports

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1025,8 +1025,8 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
       B = https://example.com:443/
     </pre>
 
-    In both sources specified ports are defalt ports for the respective schemes
-    and |B|'s path would match any path, |A| is similar to |B|.
+    Since |A| and |B| explicitly specify different ports, |A| is not
+    similar to |B|.
 
     <pre>
       A = 'sha256-abc123'
@@ -1167,7 +1167,7 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
     <pre>
       A = http://example.com:80/page1/html
       B = https://example.com:443/
-      Intersect = https://example.com:443/page1/html
+      Intersect = `null`
     </pre>
 
     <pre>


### PR DESCRIPTION
According to CSP match-ports algorithm
https://w3c.github.io/webappsec-csp/#match-ports, if a source
expression explicitly specify a port than only sources with the same
exact port will match. So the effective intersection of sources
matching both http://example.com:80/page1/html and
https://example.com:443/ is empty.

Consistently with that, the intersection of those two sources should
not be similar to each other and their intersection should be empty.