### PR TITLE
Add Trusted Types support to CSP Embedded Enforcement

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -781,7 +781,9 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
         : "`plugin-types`"
         : "`report-uri`"
         : "`require-sri-for`"
+        : "`require-trusted-types-for`"
         : "`sandbox`"
+        : "`trusted-types`"
         : "`upgrade-insecure-requests`"
         ::
             1.  If |policy|'s <a>directive set</a> <a for="set">contains</a> a <a>directive</a>


### PR DESCRIPTION
This change adds Trusted Types support to Embedded Enforcement.

Fixes: https://github.com/w3c/webappsec-csp/issues/628